### PR TITLE
feat: add mgrep semantic search tool

### DIFF
--- a/bin/juliet-bootstrap
+++ b/bin/juliet-bootstrap
@@ -403,7 +403,6 @@ setup-mgrep() {
     npm install -g @mixedbread/mgrep
   fi
   mgrep login
-  mgrep install-claude-code
 }
 
 setup-claude-code() {
@@ -417,6 +416,7 @@ setup-claude-code() {
   marketplaces=(
     "superpowers-marketplace:obra/superpowers-marketplace"
     "claude-plugins-official:anthropics/claude-plugins-official"
+    "Mixedbread-Grep:https://github.com/mixedbread-ai/mgrep"
   )
 
   # Add marketplaces if not already registered
@@ -440,6 +440,7 @@ setup-claude-code() {
     "linear@claude-plugins-official"
     "Notion@claude-plugins-official"
     "playwright@claude-plugins-official"
+    "mgrep@Mixedbread-Grep"
   )
 
   # Install plugins if not already installed

--- a/bin/juliet-bootstrap
+++ b/bin/juliet-bootstrap
@@ -397,6 +397,15 @@ EOF
   fi
 }
 
+setup-mgrep() {
+  rlog "Setting up mgrep..."
+  if ! command -v mgrep &> /dev/null; then
+    npm install -g @mixedbread/mgrep
+  fi
+  mgrep login
+  mgrep install-claude-code
+}
+
 setup-claude-code() {
   rlog "Setting up Claude Code..."
   if ! command -v claude &> /dev/null; then
@@ -440,6 +449,8 @@ setup-claude-code() {
       claude plugin install "$plugin" || warn "Failed to install $plugin"
     fi
   done
+
+  setup-mgrep
 }
 
 # =============================================================================

--- a/symlinked/home/.claude/settings.json
+++ b/symlinked/home/.claude/settings.json
@@ -71,7 +71,8 @@
     "backend-development@claude-code-workflows": true,
     "playwright@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
-    "ralph-skills@ralph-marketplace": true
+    "ralph-skills@ralph-marketplace": true,
+    "mgrep@Mixedbread-Grep": true
   },
   "alwaysThinkingEnabled": true,
   "skipDangerousModePermissionPrompt": true,

--- a/symlinked/home/.claude/settings.json
+++ b/symlinked/home/.claude/settings.json
@@ -17,6 +17,7 @@
       "Bash(head *)",
       "Bash(tail *)",
       "Bash(claude *)",
+      "Bash(mgrep *)",
       "mcp__github__search_*",
       "mcp__github__list_*",
       "mcp__github__get_*",


### PR DESCRIPTION
## Summary
- Add [mgrep](https://github.com/mixedbread-ai/mgrep) (semantic code search by mixedbread-ai) to the bootstrap flow
- Install via npm, run interactive `mgrep login`, then `mgrep install-claude-code`
- Allow `Bash(mgrep *)` in Claude Code settings

## Test plan
- [ ] Run `juliet-bootstrap --enable=claude` and verify mgrep installs and login flow works
- [ ] Confirm `mgrep <query>` works in a project after setup
- [ ] Verify Claude Code can invoke mgrep commands without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)