### PR TITLE
chore: remove dead plugin entries

### DIFF
--- a/symlinked/home/.claude/settings.json
+++ b/symlinked/home/.claude/settings.json
@@ -62,15 +62,9 @@
     "command": "printf '📍 %s' \"$(pwd)\""
   },
   "enabledPlugins": {
-    "python-development@claude-code-workflows": true,
-    "kubernetes-operations@claude-code-workflows": true,
-    "cloud-infrastructure@claude-code-workflows": true,
-    "shell-scripting@claude-code-workflows": true,
     "superpowers@superpowers-marketplace": true,
-    "backend-development@claude-code-workflows": true,
     "playwright@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true,
-    "ralph-skills@ralph-marketplace": true
+    "frontend-design@claude-plugins-official": true
   },
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",


### PR DESCRIPTION
## Summary
- Removes five `@claude-code-workflows` plugin entries and `ralph-skills@ralph-marketplace` from `enabledPlugins` in `symlinked/home/.claude/settings.json`.
- Those marketplaces are no longer declared in `extraKnownMarketplaces`, so the plugin entries are orphaned and can't resolve.
- Continues the cleanup started in 165b387 (`chore: remove dead plugins`) and ed7e166 (`chore(Claude): remove plugins replaced by remote connectors`).

## Test plan
- [ ] `python3 -c "import json; json.load(open('symlinked/home/.claude/settings.json'))"` validates
- [ ] Open a fresh Claude Code session and confirm no plugin-resolution warnings for the removed entries