### PR TITLE
nvim: start treesitter on FileType

### DIFF
--- a/symlinked/config/nvim/fnl/Juliet/plugins/language-support/nvim-treesitter.fnl
+++ b/symlinked/config/nvim/fnl/Juliet/plugins/language-support/nvim-treesitter.fnl
@@ -47,6 +47,12 @@
                               :vue
                               :yaml
                               :zig])
+                 (vim.api.nvim_create_autocmd :FileType
+                                              {:group (vim.api.nvim_create_augroup :TS_START
+                                                                                   {})
+                                               :callback (fn [args]
+                                                           (pcall vim.treesitter.start
+                                                                  args.buf))})
                  (vim.api.nvim_create_autocmd [:BufEnter
                                                :BufAdd
                                                :BufNew


### PR DESCRIPTION
## Summary
- After the migration to the `main` branch of nvim-treesitter (b908c3c), opening files (e.g. markdown) on Neovim 0.12 produced `attempt to call method 'range' (a nil value)` in `vim/treesitter.lua:196` — first from snacks scope parsing, then from the highlighter itself.
- Root cause: nvim-treesitter's `main` branch is parser-installer-only and no longer auto-attaches the highlighter. The config installs parsers but never calls `vim.treesitter.start`, so highlighting either never enables or breaks when something else (snacks) triggers a parse.
- Fix: add a `FileType` autocmd that calls `vim.treesitter.start(args.buf)`, wrapped in `pcall` so filetypes without an installed parser don't error.

This matches the setup recommended in the nvim-treesitter main-branch README.

## Test plan
- [ ] `:Lazy sync` to ensure the plugin is actually checked out on `main` (lazy-lock pins it but local checkout may still be `master`).
- [ ] `:TSUpdate` to (re)install parsers under the new API.
- [ ] Open a `.md` file — no stack trace, syntax highlighting active.
- [ ] Open files in a few other languages (lua, fish, json, ts) — highlighting works.
- [ ] Open a buffer with no installed parser (e.g. `.txt`) — no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)