### PR TITLE
nvim: sync hotpot config-cache on every startup

### DIFF
--- a/symlinked/config/nvim/fnl/Juliet/plugins/init.fnl
+++ b/symlinked/config/nvim/fnl/Juliet/plugins/init.fnl
@@ -26,6 +26,12 @@
        (let [api (require :hotpot.api)]
          (assert (api.context (vim.fn.stdpath :config)))))
 
+;; Force a sync on every startup so .fnl edits made outside nvim
+;; (git pull, stow, other editors) get picked up. Without this, hotpot's
+;; config-cache pack dir is only rebuilt the first time it's missing and
+;; via BufWritePost — so out-of-band edits go stale forever.
+(hotpot-context.sync)
+
 ((. (require :lazy) :setup) plugins
  {:ui {:border :rounded}
   :performance {:rtp {:paths [(hotpot-context.locate :destination)]}}})


### PR DESCRIPTION
## Summary
- Calls `(hotpot-context.sync)` after creating the hotpot context in `init.fnl`, so the config-cache pack dir is reconciled against the source `.fnl` tree on every nvim startup.

## Why
Hotpot's config-cache lives at `~/.local/share/nvim/site/pack/hotpot/opt/hotpot-config-cache/` and is loaded onto the rtp via `lazy.setup`'s `performance.rtp.paths`. It only gets rebuilt in two places:

1. Inside `require('hotpot')`, the first time the pack dir is missing (full sync)
2. The `BufWritePost` autocmd, when a `.fnl` is saved inside an nvim session

That means any `.fnl` edit made out-of-band — `git pull`, `git checkout`, `stow`, an editor that isn't this nvim, an nvim that crashed before `BufWritePost` — never propagates into the pack cache. The compiled `.lua` silently drifts from the source `.fnl`, and you end up running stale code until the cache is wiped manually.

This bit me with `nvim-treesitter.fnl`: the source was rewritten months ago to use the `main`-branch API (`require('nvim-treesitter').install(...)`), but the cache still had the old `master`-branch `require('nvim-treesitter.configs').setup(...)` call. Lazy was pinned to `:branch "main"` (where `nvim-treesitter.configs` no longer exists), so every startup threw `module 'nvim-treesitter.configs' not found`.

Calling `hotpot-context.sync` on startup re-checks `.fnl` mtimes against the compiled `.lua` and recompiles whatever drifted. Cheap when nothing changed, correct when something did.

## Test plan
- [ ] Wipe `~/.local/share/nvim/site/pack/hotpot/opt/hotpot-config-cache` and `~/.cache/nvim/hotpot`, start nvim — pack dir rebuilds, treesitter loads cleanly.
- [ ] Edit a `.fnl` outside nvim (e.g. `sed` or another editor), start nvim — the matching cached `.lua` reflects the edit without manual cache wipe.
- [ ] Start nvim with no `.fnl` changes — sync is a no-op, no perceptible startup regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)