### PR TITLE
nvim: install treesitter parsers under site/ so they survive plugin updates

### DIFF
--- a/symlinked/config/nvim/fnl/Juliet/plugins/language-support/nvim-treesitter.fnl
+++ b/symlinked/config/nvim/fnl/Juliet/plugins/language-support/nvim-treesitter.fnl
@@ -6,6 +6,7 @@
        :lazy false
        :config (fn []
                  (local ts (require :nvim-treesitter))
+                 (ts.setup {:install_dir (.. (vim.fn.stdpath :data) :/site)})
                  (ts.install [:bash
                               :cmake
                               :comment


### PR DESCRIPTION
## Summary
- Adds a `ts.setup {:install_dir ...}` call before `ts.install`, pointing parser output at `stdpath('data')/site` instead of the plugin's own directory.

## Why
nvim-treesitter's `main` branch defaults to writing compiled parsers into the plugin's install directory (`~/.local/share/nvim/lazy/nvim-treesitter/parser/`). Lazy.nvim treats that directory as plugin-managed, so any update / reinstall / `:Lazy clean` wipes the parsers — and every parser has to recompile from source on the next startup.

`site/parser/` is a standard `:h runtimepath` location that nvim picks up natively and that no plugin manager touches. Parsers compiled there persist across plugin updates and load with one fewer rtp lookup.

## Test plan
- [ ] Start nvim, run `:TSUpdate` (or let `:build` run), confirm parsers appear in `~/.local/share/nvim/site/parser/`.
- [ ] Run `:Lazy update nvim-treesitter` — parsers under `site/parser/` are untouched.
- [ ] Open a file in a covered language, confirm treesitter highlighting works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)