### PR TITLE
claude: enable pyright + typescript LSP plugins

### DIFF
--- a/bin/juliet-bootstrap
+++ b/bin/juliet-bootstrap
@@ -412,6 +412,32 @@ setup-pi() {
   # symlink-dotfiles(). Nothing else to do here.
 }
 
+setup-lsp-servers() {
+  rlog "Setting up LSP servers for Claude Code..."
+
+  if ! command -v npm &> /dev/null; then
+    warn "npm not found, skipping LSP server install"
+    return
+  fi
+
+  # LSP binaries referenced by symlinked/home/.claude/settings.json lspServers.
+  # Each entry: "binary-to-check:npm-packages-to-install (space-separated)"
+  local -a lsp_packages=(
+    "pyright-langserver:pyright"
+    "typescript-language-server:typescript-language-server typescript"
+  )
+
+  for pair in "${lsp_packages[@]}"; do
+    local bin="${pair%%:*}"
+    local pkgs="${pair#*:}"
+    if ! command -v "$bin" &> /dev/null; then
+      log "Installing $pkgs..."
+      # shellcheck disable=SC2086
+      npm install -g $pkgs || warn "Failed to install $pkgs"
+    fi
+  done
+}
+
 setup-claude-code() {
   rlog "Setting up Claude Code..."
   if ! command -v claude &> /dev/null; then
@@ -499,8 +525,9 @@ run-desktop() {
 }
 
 run-claude() {
-  confirm-category "claude" "Set up Claude Code? (CLI, superpowers, context7, LSP plugins)" || return
+  confirm-category "claude" "Set up Claude Code? (CLI, superpowers, context7, LSP plugins + servers)" || return
   setup-claude-code
+  setup-lsp-servers
 }
 
 run-pi() {

--- a/symlinked/home/.claude/settings.json
+++ b/symlinked/home/.claude/settings.json
@@ -95,6 +95,30 @@
       }
     }
   },
+  "lspServers": {
+    "pyright": {
+      "command": "pyright-langserver",
+      "args": ["--stdio"],
+      "extensionToLanguage": {
+        "py": "python",
+        "pyi": "python"
+      }
+    },
+    "typescript": {
+      "command": "typescript-language-server",
+      "args": ["--stdio"],
+      "extensionToLanguage": {
+        "ts": "typescript",
+        "tsx": "typescriptreact",
+        "mts": "typescript",
+        "cts": "typescript",
+        "js": "javascript",
+        "jsx": "javascriptreact",
+        "mjs": "javascript",
+        "cjs": "javascript"
+      }
+    }
+  },
   "alwaysThinkingEnabled": true,
   "promptSuggestionEnabled": false,
   "awaySummaryEnabled": false,

--- a/symlinked/home/.claude/settings.json
+++ b/symlinked/home/.claude/settings.json
@@ -66,6 +66,8 @@
     "superpowers@superpowers-marketplace": true,
     "playwright@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true,
     "codex@openai-codex": true,
     "j2-presentations@j2-claude-skills": true
   },
@@ -92,30 +94,6 @@
       "source": {
         "source": "git",
         "url": "git@github.com:j2-health/claude-plugins.git"
-      }
-    }
-  },
-  "lspServers": {
-    "pyright": {
-      "command": "pyright-langserver",
-      "args": ["--stdio"],
-      "extensionToLanguage": {
-        "py": "python",
-        "pyi": "python"
-      }
-    },
-    "typescript": {
-      "command": "typescript-language-server",
-      "args": ["--stdio"],
-      "extensionToLanguage": {
-        "ts": "typescript",
-        "tsx": "typescriptreact",
-        "mts": "typescript",
-        "cts": "typescript",
-        "js": "javascript",
-        "jsx": "javascriptreact",
-        "mjs": "javascript",
-        "cjs": "javascript"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Enables `pyright-lsp@claude-plugins-official` and `typescript-lsp@claude-plugins-official` in `symlinked/home/.claude/settings.json`. These plugins already declare the right `lspServers` config at the marketplace level — that's where Claude Code actually loads LSP configs from (the user-settings schema does not include `lspServers`).
- Adds `setup-lsp-servers()` to `bin/juliet-bootstrap`, called from `run-claude`, which idempotently installs the backing binaries (`pyright`, `typescript-language-server`, `typescript`) via `npm i -g` when not already on PATH.

## Notes / gotchas
- `npm install -g` under nodenv installs into whatever Node version is active at bootstrap time. Globals on a different nodenv version won't shim through `system`. If your default is `system` node, run `nodenv shell system` (or `nodenv global system`) before `juliet-bootstrap`, or swap to `pipx install pyright` for the Python side.
- The previous iteration of this PR added a top-level `lspServers` block to settings.json directly. That block was dead config — confirmed by reading `~/.claude/plugins/marketplaces/claude-plugins-official/.claude-plugin/marketplace.json`, which shows the LSP config lives on plugin entries, not user settings. Removed in the cleanup commit.

## Test plan
- [x] `jq . symlinked/home/.claude/settings.json` parses cleanly
- [x] `bash -n bin/juliet-bootstrap` passes
- [ ] After stow + bootstrap: `pyright-langserver --version` and `typescript-language-server --version` both succeed
- [ ] `claude plugin list | grep -A2 -E 'pyright-lsp|typescript-lsp'` shows `Status: ✔ enabled`
- [ ] In a Claude Code session, opening a `.py` or `.ts` file with a type error surfaces diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)