### PR TITLE
fix(bootstrap): stop retrying DNF packages satisfied by differently-named providers

### DIFF
--- a/bin/juliet-bootstrap
+++ b/bin/juliet-bootstrap
@@ -266,6 +266,21 @@ setup-cargo() {
   fi
 }
 
+# A DNFfile entry may be satisfied by a differently-named package: Fedora 44
+# ships node only as versioned streams (nodejs -> nodejs22 via a virtual
+# provide), kubernetes-client -> kubernetes1.36-client, and dnf resolves
+# deno -> deno-bin through /usr/bin/deno binary provides. Checking only
+# `rpm -q <name>` misses all of these, so those entries got "retried"
+# (and reported failed on any transient dnf error) on every single run.
+dnf-satisfied() {
+  rpm -q "$1" &> /dev/null && return 0
+  rpm -q --whatprovides "$1" &> /dev/null && return 0
+  # Binary/file provides need dnf's resolver; --assumeno exits 0 only when
+  # the spec is already satisfied. The cache is fresh from the transaction
+  # that just ran, so --cacheonly keeps this fast and offline.
+  dnf --cacheonly install --assumeno "$1" &> /dev/null
+}
+
 setup-dnf() {
   log "Setting up DNF packages..."
 
@@ -322,7 +337,7 @@ setup-dnf() {
     # own error instead of being silently skipped.
     failed=()
     for pkg in "${packages[@]}"; do
-      rpm -q "$pkg" &> /dev/null && continue
+      dnf-satisfied "$pkg" && continue
       log "Retrying $pkg individually..."
       sudo dnf install -y "$pkg" || failed+=("$pkg")
     done


### PR DESCRIPTION
## Problem

Every `juliet-bootstrap` run on Fedora 44 printed `Retrying nodejs individually...` and, whenever dnf hiccuped (e.g. the abandoned agraven/neovide copr with an empty f44 repo), reported **"Failed to install: nodejs ..."** — even though node is installed and working.

Root cause: the DNF retry loop verifies each DNFfile entry with `rpm -q <name>`, which checks the literal package *name*. Three entries are satisfied by differently-named packages, so the check can never pass:

| DNFfile entry | Actually installed as | Mechanism |
|---|---|---|
| `nodejs` | `nodejs22` | virtual provide (F44 ships only versioned node streams) |
| `kubernetes-client` | `kubernetes1.36-client` | virtual provide |
| `deno` | `deno-bin` | dnf binary provide (`/usr/bin/deno`) |

Each of these got a pointless ~5s individual `dnf install` retry on every run, and surfaced as a spurious install failure on any transient dnf error.

## Fix

New `dnf-satisfied()` helper used by the retry loop, checked in escalating order:
1. `rpm -q` (exact name — fast path, covers most entries)
2. `rpm -q --whatprovides` (virtual provides)
3. `dnf --cacheonly install --assumeno` (binary/file provides; exits 0 only when the spec is already satisfied; cache is fresh from the transaction that just ran)

## Verification

Ran on noelle (Fedora 44, the machine that exhibited the bug):
- `bash -n` passes
- `dnf-satisfied` returns satisfied for `nodejs`, `kubernetes-client`, `deno`, `ghostty`; NOT satisfied for `cowsay` (available, not installed) and a nonexistent package — so real gaps still get retried and reported

## Note

The working copy on noelle has an uncommitted spin/substep rework touching this same region of `setup-dnf` — resolving that conflict is one hunk: keep the rework's output style, swap its `rpm -q "$pkg"` gate for `dnf-satisfied "$pkg"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)