### PR TITLE
feat(niri): move hot corner from top-right to bottom-right

### DIFF
--- a/symlinked/config/niri/config.kdl
+++ b/symlinked/config/niri/config.kdl
@@ -290,7 +290,7 @@ spawn-at-startup "discord"
 
 gestures {
     hot-corners {
-        off
+        bottom-right
     }
 }
 

--- a/symlinked/config/niri/config.kdl
+++ b/symlinked/config/niri/config.kdl
@@ -290,7 +290,7 @@ spawn-at-startup "discord"
 
 gestures {
     hot-corners {
-        top-right
+        off
     }
 }
 


### PR DESCRIPTION
## What

Relocates the niri hot corner from the top-right to the **bottom-right**.

## Why

The top-right hot corner (which opens the Overview) was triggering accidentally. Rather than disabling hot corners entirely, move the trigger to the bottom-right corner.

```diff
 gestures {
     hot-corners {
-        top-right
+        bottom-right
     }
 }
```

## Verification

`niri validate` reports **config is valid**.

Once merged and pulled onto `main`, the change takes effect on next niri config reload (niri hot-reloads the symlinked file on save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)